### PR TITLE
Update README preserve_files to be a boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,7 +740,7 @@ An option is available to preserve attachments in order to play nicely with soft
 
 ```ruby
 has_attached_file :some_attachment, {
-    preserve_files: "true",
+    preserve_files: true,
 }
 ```
 


### PR DESCRIPTION
Before this change, the value for `preserve_files` was the string `"true"`, potentially confusing users that they should use stringified booleans like `"true"` and `"false"`.

However `"false"` would evaluate as truthy, and preserve files.
This appears to have been a factor in https://github.com/thoughtbot/paperclip/issues/1445#issuecomment-51430186
